### PR TITLE
chore: bump solidity version due to `virtual` usage

### DIFF
--- a/src/test.sol
+++ b/src/test.sol
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity >=0.5.0;
+pragma solidity >=0.6.0;
 
 contract DSTest {
     event log                    (string);


### PR DESCRIPTION
#48 marked the fail function as virtual, resulting in a compilation error in Solidity <0.6, so I bumped the version.